### PR TITLE
Dimensione thumbnail ImgBly dinamicizzata - scorporato trailer url - Aggiornamento README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Possibilità di scegliere il tipo di release da effettuare:
         - `imgbb`: Se desideri caricare le immagini su ImgBB, ottieni la [chiave API](https://api.imgbb.com/) e inseriscila qui. **Lascia vuoto per utilizzare Imgur.**
         - `tmdb`: Inserisci la chiave delle API di TheMovieDB (se non ne hai una, registrati e [ottienila qui](https://www.themoviedb.org/settings/api))
         - `imgbly`: Il caricamento su ImgBly è impostato di default a `false` ma impostandolo a `true` verrà utilizzato come scelta primaria. ImgBly verrà utilizzato anche in caso di fallimento nel caricamento delle immagini su Imgur o su ImgBB, anche in caso di screenshot troppo grandi (Imgur supporta al max 20MB mentre ImgBB 32MB) il programma sceglierà automaticamente ImgBly che ha un limite superiore (50MB)
+        - `imgbly_thumb_size`: definisce la dimensione della larghezza della thumbnail generata dall'uso di ImgBly, è personalizzabile e mantiene il rapporto d'aspetto dell'immagine originale.
     - `screenshots.txt`
         - Inserisci i timestamp dove lo script andrà ad estrarre gli screenshot
     - `template.txt`

--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ Possibilità di scegliere il tipo di release da effettuare:
 1. Rinomina la cartella `config_example` in `config`
 2. Configura lo script modificando i file nella cartella `config`
     - `keys.json`
-        - `imgbb`: Se desideri caricare le immagini su ImgBB, ottieni la [chiave API](https://api.imgbb.com/) e inseriscila qui. **Lascia vuoto per utilizzare Imgur.**
-        - `tmdb`: Inserisci la chiave delle API di TheMovieDB (se non ne hai una, registrati e [ottienila qui](https://www.themoviedb.org/settings/api))
-        - `imgbly`: Il caricamento su ImgBly è impostato di default a `false` ma impostandolo a `true` verrà utilizzato come scelta primaria. ImgBly verrà utilizzato anche in caso di fallimento nel caricamento delle immagini su Imgur o su ImgBB, anche in caso di screenshot troppo grandi (Imgur supporta al max 20MB mentre ImgBB 32MB) il programma sceglierà automaticamente ImgBly che ha un limite superiore (50MB)
-        - `imgbly_thumb_size`: definisce la dimensione della larghezza della thumbnail generata dall'uso di ImgBly, è personalizzabile e mantiene il rapporto d'aspetto dell'immagine originale.
+        - `imgbb: String`: Se desideri caricare le immagini su ImgBB, ottieni la [chiave API](https://api.imgbb.com/) e inseriscila qui. **Lascia vuoto per utilizzare Imgur.**
+        - `tmdb: String`: Inserisci la chiave delle API di TheMovieDB (se non ne hai una, registrati e [ottienila qui](https://www.themoviedb.org/settings/api))
+        - `imgbly: Bool`: Il caricamento su ImgBly è impostato di default a `false` ma impostandolo a `true` verrà utilizzato come scelta primaria. ImgBly verrà utilizzato anche in caso di fallimento nel caricamento delle immagini su Imgur o su ImgBB, anche in caso di screenshot troppo grandi (Imgur supporta al max 20MB mentre ImgBB 32MB) il programma sceglierà automaticamente ImgBly che ha un limite superiore (50MB)
+        - `imgbly_thumb_size: Number`: definisce la dimensione della larghezza della thumbnail generata dall'uso di ImgBly, è personalizzabile e mantiene il rapporto d'aspetto dell'immagine originale.
+        - `automatic_exit: Bool`: definisce il comportamento della GUI al momento del completamento del task in corso: `true` farà si che la finestra si chiuda automaticamente, `false` rimarrà aperta per una nuova operazione.
     - `screenshots.txt`
         - Inserisci i timestamp dove lo script andrà ad estrarre gli screenshot
     - `template.txt`

--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ Possibilità di scegliere il tipo di release da effettuare:
         - `imgbb: String`: Se desideri caricare le immagini su ImgBB, ottieni la [chiave API](https://api.imgbb.com/) e inseriscila qui. **Lascia vuoto per utilizzare Imgur.**
         - `tmdb: String`: Inserisci la chiave delle API di TheMovieDB (se non ne hai una, registrati e [ottienila qui](https://www.themoviedb.org/settings/api))
         - `imgbly: Bool`: Il caricamento su ImgBly è impostato di default a `false` ma impostandolo a `true` verrà utilizzato come scelta primaria. ImgBly verrà utilizzato anche in caso di fallimento nel caricamento delle immagini su Imgur o su ImgBB, anche in caso di screenshot troppo grandi (Imgur supporta al max 20MB mentre ImgBB 32MB) il programma sceglierà automaticamente ImgBly che ha un limite superiore (50MB)
-        - `imgbly_thumb_size: Number`: definisce la dimensione della larghezza della thumbnail generata dall'uso di ImgBly, è personalizzabile e mantiene il rapporto d'aspetto dell'immagine originale.
-        - `automatic_exit: Bool`: definisce il comportamento della GUI al momento del completamento del task in corso: `true` farà si che la finestra si chiuda automaticamente, `false` rimarrà aperta per una nuova operazione.
     - `screenshots.txt`
         - Inserisci i timestamp dove lo script andrà ad estrarre gli screenshot
     - `template.txt`

--- a/config_example/keys.json
+++ b/config_example/keys.json
@@ -1,5 +1,6 @@
 {
-    "imgbb": "",
-    "tmdb": "",
-    "imgbly": false
+	"imgbb": "",
+	"tmdb": "",
+	"imgbly": false,
+	"imgbly_thumb_size": 960
 }

--- a/config_example/keys.json
+++ b/config_example/keys.json
@@ -1,7 +1,5 @@
 {
 	"imgbb": "",
 	"tmdb": "",
-	"imgbly": false,
-	"imgbly_thumb_size": 640,
-	"automatic_exit": false
+	"imgbly": false
 }

--- a/config_example/keys.json
+++ b/config_example/keys.json
@@ -2,5 +2,6 @@
 	"imgbb": "",
 	"tmdb": "",
 	"imgbly": false,
-	"imgbly_thumb_size": 960
+	"imgbly_thumb_size": 960,
+	"automatic_exit": false
 }

--- a/config_example/keys.json
+++ b/config_example/keys.json
@@ -2,6 +2,6 @@
 	"imgbb": "",
 	"tmdb": "",
 	"imgbly": false,
-	"imgbly_thumb_size": 960,
+	"imgbly_thumb_size": 640,
 	"automatic_exit": false
 }

--- a/config_example/template.txt
+++ b/config_example/template.txt
@@ -26,7 +26,7 @@ $PLOT
 
 [b]TRAILER[/b]
 
-$TRAILER
+[bbvideo]$TRAILER[/bbvideo]
 
 [b]SCREENSHOTS[/b]
 

--- a/config_example/template.txt
+++ b/config_example/template.txt
@@ -26,7 +26,7 @@ $PLOT
 
 [b]TRAILER[/b]
 
-[bbvideo]$TRAILER[/bbvideo]
+[media]$TRAILER[/media]
 
 [b]SCREENSHOTS[/b]
 

--- a/gui.py
+++ b/gui.py
@@ -3,6 +3,7 @@ from tkinter import BooleanVar, StringVar, filedialog
 
 import customtkinter as ctk
 
+from src import utils
 from src.app import MakeRelease
 
 
@@ -17,8 +18,10 @@ class MyApp(ctk.CTk):
         self.geometry("400x360")
         self.grid_columnconfigure(0, weight=1)
 
-        ctk.set_appearance_mode("System")  # Modes: system (default), light, dark
-        ctk.set_default_color_theme("blue")  # Themes: blue (default), dark-blue, green
+        # Modes: system (default), light, dark
+        ctk.set_appearance_mode("System")
+        # Themes: blue (default), dark-blue, green
+        ctk.set_default_color_theme("blue")
 
         ctk.CTkLabel(
             self, text="Select the type of release", fg_color="transparent"
@@ -40,7 +43,8 @@ class MyApp(ctk.CTk):
         self.select_button = ctk.CTkButton(
             self, text="Select Path", command=self.select
         )
-        self.select_button.grid(row=3, column=0, sticky="nsew", padx=10, pady=2)
+        self.select_button.grid(
+            row=3, column=0, sticky="nsew", padx=10, pady=2)
 
         self.selected_path = StringVar(value="")
         self.selected_path_label = ctk.CTkLabel(
@@ -48,18 +52,21 @@ class MyApp(ctk.CTk):
             text="Path not selected",
             fg_color="transparent",
         )
-        self.selected_path_label.grid(row=4, column=0, sticky="w", padx=10, pady=0)
+        self.selected_path_label.grid(
+            row=4, column=0, sticky="w", padx=10, pady=0)
 
         self.make_release_button = ctk.CTkButton(
             self, text="Make Release!", state="disabled", command=self.make_release
         )
-        self.make_release_button.grid(row=5, column=0, sticky="nsew", padx=10, pady=2)
+        self.make_release_button.grid(
+            row=5, column=0, sticky="nsew", padx=10, pady=2)
 
         self.var_rename = BooleanVar(value=False)
         self.rename_option_menu = ctk.CTkSwitch(
             self, text="Rename the file", variable=self.var_rename
         )
-        self.rename_option_menu.grid(row=6, column=0, sticky="nsew", padx=10, pady=2)
+        self.rename_option_menu.grid(
+            row=6, column=0, sticky="nsew", padx=10, pady=2)
 
         # Add custom crew name
         ctk.CTkLabel(
@@ -75,7 +82,8 @@ class MyApp(ctk.CTk):
         )
         self.var_idtmdb = StringVar(value="")
         self.idtmdb_entry = ctk.CTkEntry(self, textvariable=self.var_idtmdb)
-        self.idtmdb_entry.grid(row=10, column=0, sticky="nsew", padx=10, pady=2)
+        self.idtmdb_entry.grid(
+            row=10, column=0, sticky="nsew", padx=10, pady=2)
 
         self.author_label = ctk.CTkLabel(
             self,
@@ -94,7 +102,8 @@ class MyApp(ctk.CTk):
         )
         self.check_updates.bind(
             "<Button-1>",
-            lambda e: callback("https://github.com/c137ricksanchez/automatic-releaser"),
+            lambda e: callback(
+                "https://github.com/c137ricksanchez/automatic-releaser"),
         )
         self.check_updates.grid(row=12, column=0, sticky="w", padx=10, pady=0)
 
@@ -129,7 +138,8 @@ class MyApp(ctk.CTk):
             id=self.var_idtmdb.get(),
         )
         releaser.make_release()
-        exit()
+        if utils.get_api_key("automatic_exit"):
+            exit()
 
 
 if __name__ == "__main__":

--- a/gui.py
+++ b/gui.py
@@ -3,7 +3,6 @@ from tkinter import BooleanVar, StringVar, filedialog
 
 import customtkinter as ctk
 
-from src import utils
 from src.app import MakeRelease
 
 
@@ -138,8 +137,6 @@ class MyApp(ctk.CTk):
             id=self.var_idtmdb.get(),
         )
         releaser.make_release()
-        if utils.get_api_key("automatic_exit"):
-            exit()
 
 
 if __name__ == "__main__":

--- a/src/api/imgbly.py
+++ b/src/api/imgbly.py
@@ -9,6 +9,8 @@ import requests
 from bs4 import BeautifulSoup
 from PIL import Image
 
+from .. import utils
+
 BASE_URL = "https://www.imgbly.com/"
 
 
@@ -100,7 +102,7 @@ def upload(image_data: bytes):
 
 def upload_thumb(original: Image.Image):
     # Calcola le dimensioni della thumbnail mantenendo il rapporto d'aspetto
-    width = 960
+    width = int(utils.get_api_key("imgbly_thumb_size"))
     ratio = width / float(original.size[0])
     height = int(float(original.size[1]) * ratio)
 

--- a/src/api/imgbly.py
+++ b/src/api/imgbly.py
@@ -31,7 +31,7 @@ def upload_image(path: str) -> Dict[str, str]:
         full_url = f"{BASE_URL}ib/{full_res['data']['id']}.png"
         thumb_url = f"{BASE_URL}ib/{thumb_res['data']['id']}.png"
         print(
-            f"  |---> Caricamento completato con successo:\n    |---> Piena risoluzione: {full_url} - Risoluzione ridotta: {thumb_url}"
+            f"  |---> Caricamento completato con successo:\n    |---> Piena risoluzione: {full_url} - Risoluzione ridotta: {thumb_url}\n"
         )
         return {"full": full_url, "thumb": thumb_url}
 

--- a/src/api/imgbly.py
+++ b/src/api/imgbly.py
@@ -9,8 +9,6 @@ import requests
 from bs4 import BeautifulSoup
 from PIL import Image
 
-from .. import utils
-
 BASE_URL = "https://www.imgbly.com/"
 
 
@@ -102,7 +100,7 @@ def upload(image_data: bytes):
 
 def upload_thumb(original: Image.Image):
     # Calcola le dimensioni della thumbnail mantenendo il rapporto d'aspetto
-    width = int(utils.get_api_key("imgbly_thumb_size"))
+    width = 640
     ratio = width / float(original.size[0])
     height = int(float(original.size[1]) * ratio)
 

--- a/src/images.py
+++ b/src/images.py
@@ -75,7 +75,7 @@ def is_anamorphic(path: str) -> bool:
 def upload_to_imgbb(path: str) -> Dict[str, str]:
     if get_filesize(path) > 32:
         print(
-            f"Lo screenshot: {os.path.basename(path)} - {get_filesize(path)} MB \nsupera la massima dimensione supportata da ImgBB (32 MB), effettuo il caricamento con ImgBly\n"
+            f"Lo screenshot: {os.path.basename(path)} - {get_filesize(path)} MB \nsupera la massima dimensione supportata da ImgBB (32 MB), effettuo il caricamento con ImgBly"
         )
         return imgbly.upload_image(path)
     return imgbb.upload_image(path)
@@ -84,7 +84,7 @@ def upload_to_imgbb(path: str) -> Dict[str, str]:
 def upload_to_imgur(path: str) -> Dict[str, str]:
     if get_filesize(path) > 10:
         print(
-            f"Lo screenshot: {os.path.basename(path)} - {round(get_filesize(path), 2)} MB \nsupera la massima dimensione supportata da Imgur (10 MB), effettuo il caricamento con ImgBly\n"
+            f"Lo screenshot: {os.path.basename(path)} - {round(get_filesize(path), 2)} MB \nsupera la massima dimensione supportata da Imgur (10 MB), effettuo il caricamento con ImgBly"
         )
         return imgbly.upload_image(path)
     return imgur.upload_image(path)

--- a/src/post.py
+++ b/src/post.py
@@ -32,7 +32,7 @@ def generate_text(
     plot = metadata["plot"] if metadata["plot"] != "" else "<NON TROVATO>"
 
     trailer = (
-        "[media]" + metadata["trailer"] + "[/media]"
+        metadata["trailer"]
         if metadata["trailer"] != ""
         else "<NON TROVATO>"
     )

--- a/src/tag.py
+++ b/src/tag.py
@@ -62,7 +62,10 @@ def parse(filename: str, title: str, year: str, crew: str) -> str:
     tags["a"] = list(dict.fromkeys(tags["a"]))
     tags["s"] = list(dict.fromkeys(tags["s"]))
 
-    tags["s"] = "Sub " + " ".join(tags["s"]) if tags["s"] else ""
+    if len(tags["s"]) > 3:
+        tags["s"] = "MultiSub"
+    else:
+        tags["s"] = "Sub " + " ".join(tags["s"]) if tags["s"] else ""
 
     tag = tags["v"] + " " + " ".join(tags["a"]) + " " + tags["s"]
 


### PR DESCRIPTION
* dimensione thumbnail resa dinamica per ImgBly tramite variabile impostabile dall'utente dal keys.json appena sotto il booleano ImgBly ho aggiunto la variabile imgbly_thumb_size con il default a 960 ma ovviamente modificabile dall'utente
* ho scorporato il trailer dal bbcode e aggiornato il template.txt in modo da avere [bbvideo]$TRAILER[/bbvideo] così che uno se lo può personalizzare come vuole
* aggiornato il readme di conseguenza (per la parte della thumb size)