### PR TITLE
Update countries_ISO_3166-1_alpha2.json

### DIFF
--- a/src/makerelease/countries_ISO_3166-1_alpha2.json
+++ b/src/makerelease/countries_ISO_3166-1_alpha2.json
@@ -216,6 +216,7 @@
     "SD": "Sudan",
     "SS": "Sudan del Sud",
     "SR": "Suriname",
+    "SU": "Unione Sovietica",
     "SJ": "Svalbard e Jan Mayen",
     "SE": "Svezia",
     "CH": "Svizzera",


### PR DESCRIPTION
Add missing 'SU' country code mapping for Soviet Union
Fixes KeyError when TMDB returns 'SU' as production country code for older films.